### PR TITLE
fix persistent socket connections after leaving game

### DIFF
--- a/static/gameBoard.js
+++ b/static/gameBoard.js
@@ -387,13 +387,6 @@ var GameBoard = new Phaser.Class ({
                 break;
             }
         });
-
-        // Warn players that they'll be disconnected if they leave
-        window.onbeforeunload = function() {
-            return 'If you leave this page, you will be removed from the game. ' +
-            'Are you sure you want to leave?';
-        };
-
     },
 
     makeEquipment: function(card, i) {

--- a/static/setup.js
+++ b/static/setup.js
@@ -16,7 +16,10 @@ $('document').ready(function() {
     }
 
     // Initial connection
-    socket = io.connect('http://' + document.domain + ':' + location.port, {reconnection: false});
+    socket = io.connect('http://' + document.domain + ':' + location.port, {
+        reconnection: false,
+        'sync disconnect on unload': true
+    });
     socket.on('connect', function() {
 
         // User joins the room
@@ -149,6 +152,11 @@ $('document').ready(function() {
                   "where you may reconnect if you were in a game.");
             window.location = "/";
         });
+
+        // Close window handler
+        window.onbeforeunload = function() {
+            socket.close();
+        }
 
         // Configure game
         var config = {


### PR DESCRIPTION
This PR fixes a part of #217 which was present across all browsers, due to the server not properly receiving socket disconnects when a client would close their browser window or navigate away from a game in progress.