### PR TITLE
Rule change: player must re-roll movement until they would actually change area (can't stay in same spot)

### DIFF
--- a/shadow-hunters/player.py
+++ b/shadow-hunters/player.py
@@ -307,10 +307,8 @@ class Player:
 
         # Preprocess all rolls
         assert four or six
-        r4 = self.gc.die4.roll()
-        r6 = self.gc.die6.roll()
-        r4 = r4 if four else 0
-        r6 = r6 if six else 0
+        r4 = self.gc.die4.roll() if four else 0
+        r6 = self.gc.die6.roll() if six else 0
         result = binop(max(r4, r6), min(r4, r6))
 
         # Set prompt based on type of roll

--- a/shadow-hunters/single_use.py
+++ b/shadow-hunters/single_use.py
@@ -84,7 +84,7 @@ def blessing(args):
     target = args['self'].choosePlayer()
 
     # Roll dice to get value to heal by
-    roll_result = args['self'].rollDice('6')
+    roll_result = args['self'].rollDice(four=False, six=True)
 
     # Heal target player
     target.moveDamage(roll_result, args['self'])
@@ -243,7 +243,7 @@ def dynamite(args):
         'confirm', {'options': ["Light the fuse"]}, args['self'].user_id)
     args['self'].gc.tell_h("{} is rolling for where the dynamite lands...", [
                            args['self'].user_id])
-    roll_result = args['self'].rollDice('area')
+    roll_result = args['self'].rollDice()
 
     # Hit area corresponding to roll number
     if roll_result == 7:
@@ -276,7 +276,7 @@ def spiritual_doll(args):
     target = args['self'].choosePlayer()
 
     # Roll 6-sided die
-    roll_result = args['self'].rollDice('6')
+    roll_result = args['self'].rollDice(four=False, six=True)
 
     # If roll is >= 5, user takes 3 damage. Otherwise, target takes 3 damage.
     if roll_result >= 5:

--- a/shadow-hunters/specials.py
+++ b/shadow-hunters/specials.py
@@ -59,7 +59,7 @@ def george(gc, player, turn_pos):
             target_Player = player.choosePlayer()
 
             # Roll and give damage to target
-            roll_result = player.rollDice('4')
+            roll_result = player.rollDice(four=True, six=False)
             target_Player.moveDamage(-1 * roll_result, player)
             gc.tell_h("{}'s Hammer gave {} {} damage!", [
                       player.user_id, target_Player.user_id, roll_result])
@@ -104,7 +104,7 @@ def franklin(gc, player, turn_pos):
             target_Player = player.choosePlayer()
 
             # Roll and give damage to target
-            roll_result = player.rollDice('6')
+            roll_result = player.rollDice(four=False, six=True)
             target_Player.moveDamage(-1 * roll_result, player)
             gc.tell_h("{}'s Lightning gave {} {} damage!", [
                       player.user_id, target_Player.user_id, roll_result])
@@ -143,7 +143,7 @@ def valkyrie(gc, player, turn_pos):
         gc.tell_h("{} ({}) used their special ability: {}", [
                   player.user_id, player.character.name,
                   player.character.special_desc])
-        player.modifiers['attack_dice_type'] = "4"
+        player.modifiers['attack_dice_type'] = {'four': True, 'six': False}
         player.modifiers['special_active'] = True
 
 

--- a/shadow-hunters/tests/class_tests/test_player.py
+++ b/shadow-hunters/tests/class_tests/test_player.py
@@ -6,6 +6,7 @@ from character import Character
 import helpers as H
 import constants as C
 import copy
+import operator
 
 
 # test_player.py
@@ -26,7 +27,7 @@ def test_fields():
     assert not p.character
     assert not p.location
     assert not p.equipment
-    assert p.modifiers['attack_dice_type'] == 'attack'
+    assert p.modifiers['attack_dice_type'] == {'four': True, 'six': True}
     assert p.damage == 0
     assert not p.ai
 
@@ -103,19 +104,19 @@ def test_rollDice():
 
     # Check 4-sided rolls
     for _ in range(C.N_ELEMENT_TESTS):
-        assert 1 <= p1.rollDice('4') <= 4
+        assert 1 <= p1.rollDice(four=True, six=False) <= 4
 
     # Check 6-sided rolls
     for _ in range(C.N_ELEMENT_TESTS):
-        assert 1 <= p1.rollDice('6') <= 6
+        assert 1 <= p1.rollDice(four=False, six=True) <= 6
 
     # Check movement rolls
     for _ in range(C.N_ELEMENT_TESTS):
-        assert 2 <= p1.rollDice('area') <= 10
+        assert 2 <= p1.rollDice(binop=operator.add) <= 10
 
     # Check attack rolls
     for _ in range(C.N_ELEMENT_TESTS):
-        assert 0 <= p1.rollDice('attack') <= 5
+        assert 0 <= p1.rollDice(binop=operator.sub) <= 5
 
 
 def test_choosePlayer():

--- a/shadow-hunters/tests/integration_tests/test_gameplay.py
+++ b/shadow-hunters/tests/integration_tests/test_gameplay.py
@@ -35,6 +35,6 @@ def test_regression():
             gc, ef = fresh_gc_ef(n)
             game_hashes += gc.play(debug=True)
 
-    correct_hash = 'bpFTiIs0rNqXbbs238PRcwMrTBznKfuDb7t8w9btxQY='
+    correct_hash = 'Cyn0G2mKoy8aLZlhUgI1M/N8/8OzxWcFcF8KSn1BNh4='
     found_hash = make_hash_sha256(game_hashes)
     assert correct_hash == found_hash

--- a/shadow-hunters/tests/integration_tests/test_gameplay.py
+++ b/shadow-hunters/tests/integration_tests/test_gameplay.py
@@ -35,6 +35,6 @@ def test_regression():
             gc, ef = fresh_gc_ef(n)
             game_hashes += gc.play(debug=True)
 
-    correct_hash = 'Cyn0G2mKoy8aLZlhUgI1M/N8/8OzxWcFcF8KSn1BNh4='
+    correct_hash = 'F01h50UD+bJTj/mD3XCM9ocKOEDsCa3MjnnLznBjT+A='
     found_hash = make_hash_sha256(game_hashes)
     assert correct_hash == found_hash

--- a/templates/rules.html
+++ b/templates/rules.html
@@ -194,7 +194,9 @@
       <p>
         At the beginning of every turn, the acting player must move to an area on the board by rolling both dice.  A prompt to roll the dice will appear on the board, and the dice will be rolled when it is clicked.<br>
         <br>
-        The numbers on the dice are summed, and the player moves to the area card with the corresponding number on it.  If the dice sum to 7, then the player can pick an area to move to &ndash; there is no area card with a 7 on it.
+        The numbers on the dice are summed, and the player moves to the area card with the corresponding number on it.  If the roll does not cause the player to move (because they are already at the corresponding area card), they must re-roll until it does.<br>
+        <br>
+        If the dice sum to 7, then the player can pick any area other than their current area to move to &ndash; there is no area card with a 7 on it.
       </p>
       <h3>Area Actions</h3>
       <p>


### PR DESCRIPTION
Moreover, when a player rolls a 7, they can no longer select the area they are already at. This change reflects the rules of the game as written in the rulebook.

There doesn't appear to be any official information from the creators on how this rule should interact with the Mystic Compass equipment. We have chosen to implement the "two legal moves" approach, i.e. the player gets a choice between two legal moves. Example:

If a player with the Mystic Compass is at the Church and rolls a 6, they re-roll it immediately until it is a legal roll (not a 6). THEN they make their second roll with the Mystic Compass. If they roll a 6, they again re-roll it until it is a legal roll. 

Thus the player always have a choice between two legal rolls. Note that this does not prevent the two legal rolls from being the same, e.g. the player in the example above could roll two 8s.

See this thread for discussion: https://boardgamegeek.com/thread/552252/mystic-compass

Additionally, if a player rolls a 7 they will no longer be prompted to use the Mystic Compass (since this would be redundant). They simply move on to selecting an area. Likewise, if the second roll with the Mystic Compass is a 7, the player is not prompted to choose which roll to keep - the 7 is chosen implicitly.